### PR TITLE
Overhaul the API surface

### DIFF
--- a/chrome-implementation-differences.md
+++ b/chrome-implementation-differences.md
@@ -1,8 +1,14 @@
 # Differences Between the Chrome Implementation and the Explainer
 
-The [explainer](./README.md) focuses on the design we're aiming to build. The current implementation in Chrome is being actively developed. It does not yet include all that functionality, and has several important differences. This document documents those differences with links to appropriate tracking bugs.
+The [explainer](./README.md) focuses on the design we're aiming to build. The current implementation in Chrome is being actively developed. It does not yet include all that functionality, and has several important differences. This document lists those differences with links to appropriate tracking bugs.
 
 The Chromium bug component for this API is [Chromium > Blink > AI > Prompt](https://issues.chromium.org/issues?q=componentid:1583624).
+
+## Overall API surface
+
+_Tracking issue: <https://issues.chromium.org/issues/355967885>_
+
+The overall API surface of the proposal changed significantly in [#25](https://github.com/explainers-by-googlers/prompt-api/pull/25). These changes have not yet been implemented in Chromium.
 
 ## Streaming
 
@@ -19,14 +25,6 @@ for await (const chunk of stream) {
 will log something like `"Hello"`, `"Hello world"`, `"Hello world I am"`, `"Hello world I am an AI"`.
 
 This is not intended behavior. We hope to eventually make this stream behave the same as other streaming APIs on the platform, where the chunks are successive pieces of a single long stream. In the future, the output will become something like `"Hello"`, `" world"`, `" I am"`, `" an AI"`.
-
-## Session persistence and cloning
-
-_Tracking issue: <https://issues.chromium.org/issues/342939486>_
-
-Currently, although there is an object called `AITextSession`, in Chromium this isn't actually treated as a session. The information you send to the model is not retained, so you have to re-send the whole conversation every time. Each call to `prompt()`/`promptStreaming()` is independent.
-
-For this reason, currently there is no `clone()` method implemented.
 
 ## Automatic downloading and download progress
 
@@ -45,9 +43,3 @@ The `systemPrompt` and `initialPrompts` options are not yet supported. Instead, 
 _Tracking issue: <https://issues.chromium.org/issues/343600797>_
 
 Currently Chrome requires that you supply both `topK` and `temperature` if you are going to include either; you cannot just include one and leave the other at its default value.
-
-## `textModelInfo()` not implemented
-
-_Tracking issue: <https://issues.chromium.org/issues/344359526>_
-
-Currently Chrome has an older design of `defaultTextSessionOptions()` which returns `{ temperature, topK }`. That method will soon be replaced by the explainer's `textModelInfo()` method.


### PR DESCRIPTION
This creates a uniform API surface with other built-in AI APIs such as translation.

Fixes #1 by moving from "text session" to "assistant". Fixes #21 by adding AbortSignals in multiple places.