### PR TITLE
Update samplingMode preset documentation and WebIDL enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,9 @@ Developers can specify a high-level `samplingMode` during session creation to co
 The allowed values for `samplingMode` are:
 *   `"most-predictable"`: For tasks requiring strict consistency and reproducibility (e.g. testing, code generation, or content extraction).
 *   `"predictable"`: For focused outputs with minimal variation.
+*   `"slightly-predictable"`: For focused outputs with a bit more variation than `"predictable"`.
 *   `"balanced"` (default): The standard preset for most conversational interactions.
+*   `"slightly-creative"`: For creative outputs that are slightly more focused than `"creative"`.
 *   `"creative"`: For tasks where variety and creativity are preferred over strict reproducibility.
 *   `"most-creative"`: For maximum diversity of output and creative brainstorming.
 

--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ dictionary LanguageModelMessageContent {
   required LanguageModelMessageValue value;
 };
 
-enum LanguageModelSamplingMode { "most-predictable", "predictable", "balanced", "creative", "most-creative" };
+enum LanguageModelSamplingMode { "most-predictable", "predictable", "slightly-predictable", "balanced", "slightly-creative", "creative", "most-creative" };
 
 enum LanguageModelMessageRole { "system", "user", "assistant" };
 


### PR DESCRIPTION
### Proposal: Add intermediate sampling modes (`slightly-predictable` and `slightly-creative`)

This PR expands the Prompt API's `LanguageModelSamplingMode` enum with two intermediate presets to cover the gaps in the preset spectrum:
- **`slightly-predictable`**: For focused outputs with a bit more variation than `predictable`.
- **`slightly-creative`**: For creative outputs that are slightly more focused than `creative`.

#### Spec & Explainer Changes:
* Expose `slightly-predictable` and `slightly-creative` in the `LanguageModelSamplingMode` WebIDL enum in `index.bs`.
* Document the new modes and their descriptions in the `README.md` explainer.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 28, 2026, 8:56 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fisaacahouma%2Fprompt-api%2Ffb0117075ee6b619022c12641ea961308e7143e7%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "329:44",
        "messageType": "link",
        "text": "Multiple possible 'getting the language availabilities partition' dfn refs.\nArbitrarily chose https://webmachinelearning.github.io/proofreader-api/#get-the-language-availabilities-partition\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:proofreader-api; type:dfn; text:get the language availabilities partition\nspec:writing-assistance-apis; type:dfn; text:get the language availabilities partition"
    },
    {
        "lineNum": "331:45",
        "messageType": "link",
        "text": "Multiple possible 'getting the language availabilities partition' dfn refs.\nArbitrarily chose https://webmachinelearning.github.io/proofreader-api/#get-the-language-availabilities-partition\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:proofreader-api; type:dfn; text:get the language availabilities partition\nspec:writing-assistance-apis; type:dfn; text:get the language availabilities partition"
    },
    {
        "lineNum": "335:59",
        "messageType": "link",
        "text": "Multiple possible 'computing language availability' dfn refs.\nArbitrarily chose https://webmachinelearning.github.io/proofreader-api/#compute-language-availability\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:proofreader-api; type:dfn; text:compute language availability\nspec:writing-assistance-apis; type:dfn; text:compute language availability"
    },
    {
        "lineNum": "342:60",
        "messageType": "link",
        "text": "Multiple possible 'computing language availability' dfn refs.\nArbitrarily chose https://webmachinelearning.github.io/proofreader-api/#compute-language-availability\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:proofreader-api; type:dfn; text:compute language availability\nspec:writing-assistance-apis; type:dfn; text:compute language availability"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20webmachinelearning/prompt-api%23210.)._

</details>
