### PR TITLE
Disambiguate definitions from Writing Assistance API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,8 +19,12 @@ Die On: warning
 </pre>
 
 <pre class="link-defaults">
-spec:webidl; type:exception; text:TypeError
-spec:webidl; type:exception; text:SyntaxError
+spec:webidl
+  type:exception; text:TypeError
+  type:exception; text:SyntaxError
+spec: writing-assistance-apis
+  type: dfn; text: computing language availability
+  type: dfn; text: getting the language availabilities partition
 </pre>
 
 <h2 id="intro">Introduction</h2>


### PR DESCRIPTION
These concepts are currently defined by both the Writing Assistance API specification and the Proofreader API specification. Add them to link-defaults to fix the build errors while we want for the duplication to be resolved upstream.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/prompt-api/pull/211.html" title="Last updated on Jul 29, 2026, 10:16 PM UTC (bfdd950)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/prompt-api/211/97be25f...bfdd950.html" title="Last updated on Jul 29, 2026, 10:16 PM UTC (bfdd950)">Diff</a>