### PR TITLE
Remove samplingMode default from IDL; update comments

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -63,7 +63,6 @@ interface LanguageModel : EventTarget {
     optional LanguageModelAppendOptions options = {}
   );
 
-
   Promise<double> measureContextUsage(
     LanguageModelPrompt input,
     optional LanguageModelPromptOptions options = {}
@@ -84,18 +83,19 @@ interface LanguageModel : EventTarget {
   // **DEPRECATED**: This attribute is only available in extension contexts.
   attribute EventHandler onquotaoverflow;
 
-  // **EXPERIMENTAL**: Only available in extension and experimental contexts.
+  // **DEPRECATED**: This attribute is only available in extension contexts.
   readonly attribute unsigned long topK;
-  // **EXPERIMENTAL**: Only available in extension and experimental contexts.
+  // **DEPRECATED**: This attribute is only available in extension contexts.
   readonly attribute float temperature;
 
+  // **EXPERIMENTAL**: Only available in experimental contexts.
   readonly attribute LanguageModelSamplingMode samplingMode;
 
   Promise<LanguageModel> clone(optional LanguageModelCloneOptions options = {});
 };
 LanguageModel includes DestroyableModel;
 
-// **EXPERIMENTAL**: Only available in extension and experimental contexts.
+// **DEPRECATED**: Only available in extension contexts.
 [Exposed=Window, SecureContext]
 interface LanguageModelParams {
   readonly attribute unsigned long defaultTopK;
@@ -103,7 +103,6 @@ interface LanguageModelParams {
   readonly attribute float defaultTemperature;
   readonly attribute float maxTemperature;
 };
-
 
 callback LanguageModelToolFunction = Promise<DOMString> (any... arguments);
 
@@ -120,15 +119,20 @@ dictionary LanguageModelTool {
 dictionary LanguageModelCreateCoreOptions {
   // Note: these two have custom out-of-range handling behavior, not in the IDL layer.
   // They are unrestricted double so as to allow +Infinity without failing.
-  // **EXPERIMENTAL**: Only available in extension and experimental contexts.
+  // **DEPRECATED**: Only available in extension contexts.
   unrestricted double topK;
-  // **EXPERIMENTAL**: Only available in extension and experimental contexts.
+  // **DEPRECATED**: Only available in extension contexts.
   unrestricted double temperature;
 
-  LanguageModelSamplingMode samplingMode = "default";
+  // **EXPERIMENTAL**: Only available in experimental contexts.
+  LanguageModelSamplingMode samplingMode;
 
+  // The expected types and languages for the session.
   sequence<LanguageModelExpected> expectedInputs;
   sequence<LanguageModelExpected> expectedOutputs;
+
+  // Tools that the language model can use.
+  // **EXPERIMENTAL**: Only available in experimental contexts.
   sequence<LanguageModelTool> tools;
 };
 
@@ -813,7 +817,6 @@ When prompting fails, the following possible reasons may be surfaced to the web 
 </table>
 
 <p class="note">This table does not give the complete list of exceptions that can be surfaced by the prompt API. It only contains those which can come from certain [=implementation-defined=] steps.
-
 
 <div algorithm>
   To <dfn>clone a language model</dfn> given a {{LanguageModel}} |model| and a {{LanguageModelCloneOptions}} |options|:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/michaelwasserman/prompt-api/pull/215.html" title="Last updated on Aug 11, 2026, 6:08 PM UTC (eb417b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/prompt-api/215/849f435...michaelwasserman:eb417b3.html" title="Last updated on Aug 11, 2026, 6:08 PM UTC (eb417b3)">Diff</a>